### PR TITLE
Adding PNG metadata containing the prompts and generation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and it can be compiled with `./build_lib.sh --config Release --update --build --
 
 The GUI can be executed with `mvn package exec:exec -DmodelPath=<path-to-stable-diffusion-model>`. It constructs a
 window where you can specify the parameters of the image you'd like to generate, and each image creates its own window
-where it can save the image as a png file.
+where it can save the image as a png file. Saved png files contain a metadata field with the generation parameters.
 
 ### Use in other programs
 

--- a/src/main/java/com/oracle/labs/mlrg/sd4j/CLIApp.java
+++ b/src/main/java/com/oracle/labs/mlrg/sd4j/CLIApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
  *
  * The Universal Permissive License (UPL), Version 1.0
  *
@@ -77,13 +77,13 @@ public final class CLIApp {
         List<SD4J.SDImage> images = sd.generateImage(30, text, "", 7.5f, 1, new SD4J.ImageSize(512, 512), seed);
         String output = "output-"+seed+".png";
         logger.info("Saving to " + output);
-        SD4J.save(images.get(0).image(), output);
+        SD4J.save(images.get(0), output);
 
         String negativeText = "red tree, green sky";
         images = sd.generateImage(30, text, negativeText, 7.5f, 1, new SD4J.ImageSize(512, 512), seed);
         output = "output-neg-"+seed+".png";
         logger.info("Saving to " + output);
-        SD4J.save(images.get(0).image(), output);
+        SD4J.save(images.get(0), output);
 
         sd.close();
     }

--- a/src/main/java/com/oracle/labs/mlrg/sd4j/SD4JApp.java
+++ b/src/main/java/com/oracle/labs/mlrg/sd4j/SD4JApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
  *
  * The Universal Permissive License (UPL), Version 1.0
  *
@@ -327,7 +327,7 @@ public final class SD4JApp extends JFrame {
                     }
                     logger.info("Saving file to " + file.getName());
                     try {
-                        SD4J.save(image.image(), file);
+                        SD4J.save(image, file);
                     } catch (IOException ex) {
                         logger.log(Level.WARNING, "Failed to save file", ex);
                     }

--- a/src/main/java/com/oracle/labs/mlrg/sd4j/Schedulers.java
+++ b/src/main/java/com/oracle/labs/mlrg/sd4j/Schedulers.java
@@ -46,23 +46,33 @@ public enum Schedulers {
     /**
      * A Linear Multi-Step scheduler.
      */
-    LMS(a -> new LMSDiscreteScheduler(), "LMS"),
+    LMS(a -> new LMSDiscreteScheduler(), "LMS", "LMS"),
     /**
      * An Euler Ancestral scheduler.
      */
-    EULER_ANCESTRAL(EulerAncestralDiscreteScheduler::new, "Euler Ancestral");
+    EULER_ANCESTRAL(EulerAncestralDiscreteScheduler::new, "Euler Ancestral", "Euler a");
 
     final Function<Long, Scheduler> factory;
     final String displayName;
+    final String descriptionName;
 
-    Schedulers(Function<Long,Scheduler> factory, String displayName) {
+    Schedulers(Function<Long,Scheduler> factory, String displayName, String descriptionName) {
         this.factory = factory;
         this.displayName = displayName;
+        this.descriptionName = descriptionName;
     }
 
     @Override
     public String toString() {
         return displayName;
+    }
+
+    /**
+     * The name to be used in the image metadata.
+     * @return The image metadata scheduler name.
+     */
+    public String descriptionName() {
+        return descriptionName;
     }
 
     /**


### PR DESCRIPTION
Adds PNG metadata containing the generation request parameters and the model name (which is the folder name the model was loaded from). The metadata roughly conforms to automatic1111/stable-diffusion-webui's metadata format.

Refactored the `save` method to take an `SDImage`, refactored `SDImage` to take a `Request` and made the `generateImage` that accepts a `Request` be the base one rather than unpacking it into the arguments list. This was done to make it easier to pass the `Request` all the way through to `save` where it can generate the PNG metadata.