### PR TITLE
Allow using OpenVINO

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,15 @@ directly from other code.
 
 ### Using a CUDA GPU
 
-To use the GPU you need to modify the pom file to depend on `onnxruntime_gpu` and swap `<argument>CPU</argument>` for
-`<argument>CUDA</argument>` in the `exec-maven-plugin` block.
+To use the GPU you need to modify the pom file to depend on `onnxruntime_gpu` and swap `<executionProvider>CPU</executionProvider>` to
+`<executionProvider>CUDA</executionProvider>` in the Maven `<properties>` block.
+You can also specify `-DexecutionProvider=CUDA` when executing the GUI with `mvn package exec:exec`.
+
+### Using OpenVINO
+
+To enable OpenVINO acceleration, you need to ensure ONNX Runtime library referenced in the pom.xml has been build with OpenVINO explicitly enabled, so that the [OpenVINO Execution Provider](https://onnxruntime.ai/docs/build/eps.html) is included in the Java library pulled by the Maven reactor.
+Then you can swap `<executionProvider>CPU</executionProvider>` to
+`<executionProvider>OPENVINO</executionProvider>` in the Maven `<properties>` block; you can also specify `-DexecutionProvider=OPENVINO` when executing the GUI with `mvn package exec:exec`.
 
 ## Implementation details
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
-        <onnxruntime.version>1.14.0</onnxruntime.version>
+        <onnxruntime.version>1.20.0</onnxruntime.version>
         <modelPath></modelPath>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <onnxruntime.version>1.20.0</onnxruntime.version>
+        <executionProvider>CPU</executionProvider>
         <modelPath></modelPath>
     </properties>
 
@@ -151,7 +152,7 @@
                         <argument>--model-path</argument>
                         <argument>${modelPath}</argument>
                         <argument>--execution-provider</argument>
-                        <argument>CPU</argument>
+                        <argument>${executionProvider}</argument>
                     </arguments>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The patch here makes it easier to enable OpenVINO acceleration.
I've successfully tested this with OpenVINO 2024.6 and ONNX Runtime 1.20.0/1/2, rebuilt from sources to enable openvino CPU support (I don't have NPU or GPU, running on a 11th Gen Intel(R) Core(TM) i7-11850H).

Thanks for the nice project :)